### PR TITLE
Spell miss fix.

### DIFF
--- a/tmpl/index.htm.in
+++ b/tmpl/index.htm.in
@@ -58,7 +58,7 @@
    {
        var disabled = false;
 
-       if ("@ENPTY_COMMENT@" != "on") {
+       if ("@EMPTY_COMMENT@" != "on") {
            disabled |= (document.getElementById('upload_comment').value.length == 0);
        }
 


### PR DESCRIPTION
--enable-empty-comment オプションがテンプレートのスペルミスで正しく動作していなかったため修正しました。
